### PR TITLE
separate provider between gmail and googlemail

### DIFF
--- a/lib/normailize/provider/gmail.rb
+++ b/lib/normailize/provider/gmail.rb
@@ -6,7 +6,7 @@ module Normailize
       include Normailize::Provider
 
       # Gmail addresses work on both gmail.com and googlemail.com
-      set_domains 'gmail.com', 'googlemail.com', 'google.com'
+      set_domains 'gmail.com', 'google.com'
 
       # A normalized Gmail address is lowercased, dots and everything after a
       # plus sign is removed from the username part

--- a/lib/normailize/provider/googlemail.rb
+++ b/lib/normailize/provider/googlemail.rb
@@ -1,0 +1,11 @@
+module Normailize
+  module Provider
+    class GoogleMail
+      include Normailize::Provider
+
+      set_domains 'googlemail.com'
+
+      set_modifications :lowercase, :remove_plus_part
+    end
+  end
+end

--- a/lib/normailize/util/email_validator.rb
+++ b/lib/normailize/util/email_validator.rb
@@ -101,7 +101,7 @@ module Normailize
           @valid_mx = true
           # Google Apps for Work
           if /aspmx.*google.*\.com\.?$/i =~ mx
-            @provider = 'gmail.com'
+            @provider = 'googlemail.com'
           # FastMail @domain
           elsif /\.messagingengine\.com\.?$/i =~ mx
             @provider = 'fastmail.com'


### PR DESCRIPTION
cc Pak @fajarb 

this PR enables differentiation between googlemail.com and gmail.com